### PR TITLE
Add threat assessment job to CI workflow

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -78,7 +78,7 @@ jobs:
           rl-submit-only: false
           artifact-to-scan: ${{ steps.build.outputs.scanfile }}
           report-path: report
-          rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}
+          rl-package-url: common/releases@${{ steps.get_version.outputs.version }}
       - name: Archive scan report
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -39,6 +39,40 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm run build # Automatically run tests because of the `postbuild` script in package.json
+  
+  threat-assessment:
+    name: Threat Assessment
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get package version
+        id: get_version
+        run: |
+          # Extract the version from package.json and set it as an environment variable
+          echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+
+      # Create an archive of the package
+      - id: build
+        run: |
+          npm pack
+          # Capture the path of the generated tarball
+          echo "scanfile=$(ls *.tgz)" >> $GITHUB_OUTPUT
+      # Use the rl-scanner-cloud-composite action
+      - name: Scan build artifact on the Portal
+        id: rl-scan
+        env:
+          RLPORTAL_ACCESS_TOKEN: ${{ secrets.RLPORTAL_ACCESS_TOKEN }}
+        uses: reversinglabs/gh-action-rl-scanner-cloud-composite@v1
+        with:
+          rl-verbose: true
+          rl-portal-server: trial
+          rl-portal-org: Trial
+          rl-portal-group: OSS-MannySilva
+          rl-timeout: 20
+          rl-submit-only: false
+          artifact-to-scan: ${{ steps.build.outputs.scanfile }}
+          rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}-assess.0
 
   publish-npm:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -53,7 +53,11 @@ jobs:
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       # Create an archive of the package
-      - run: mkdir -p build
+      - name: Set Current Date Time
+        run: |
+          echo "DT_NOW=$(date +%Y%m%d-%H%M%S)" >> ${GITHUB_ENV}
+      - name: Create directories
+        run: mkdir -p build report
       - id: build
         run: |
           npm pack
@@ -73,12 +77,19 @@ jobs:
           rl-timeout: 20
           rl-submit-only: false
           artifact-to-scan: ${{ steps.build.outputs.scanfile }}
+          report-path: report
           rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}-assess.0
-      - name: Output scan status
+      - name: Output and archive scan report
         if: success() || failure()
         run: |
           echo "The status is: '${{ steps.rl-scan.outputs.status }}'"
           echo "The description is: '${{ steps.rl-scan.outputs.description }}'"
+      - name: Archive scan report
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rl-scan-report-${{ env.DT_NOW }}
+          path: report
 
   publish-npm:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -60,7 +60,7 @@ jobs:
         run: mkdir -p build report
       - id: build
         run: |
-          npm pack
+          npm pack --pack-destination build
           # Capture the path of the generated tarball
           echo "scanfile=$(ls build/*.tgz)" >> $GITHUB_OUTPUT
       # Use the rl-scanner-cloud-composite action

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -41,6 +41,7 @@ jobs:
       - run: npm run build # Automatically run tests because of the `postbuild` script in package.json
   
   threat-assessment:
+    if: github.event_name == 'release' && github.event.action == 'published'
     name: Threat Assessment
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -64,7 +64,7 @@ jobs:
         id: rl-scan
         env:
           RLPORTAL_ACCESS_TOKEN: ${{ secrets.RLPORTAL_ACCESS_TOKEN }}
-        uses: reversinglabs/gh-action-rl-scanner-cloud-composite@v1
+        uses: reversinglabs/gh-action-rl-scanner-cloud-only@v1
         with:
           rl-verbose: true
           rl-portal-server: trial
@@ -83,7 +83,7 @@ jobs:
   publish-npm:
     if: github.event_name == 'release' && github.event.action == 'published'
     name: Publish to NPM
-    needs: test
+    needs: threat-assessment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -78,12 +78,7 @@ jobs:
           rl-submit-only: false
           artifact-to-scan: ${{ steps.build.outputs.scanfile }}
           report-path: report
-          rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}-assess.0
-      - name: Output and archive scan report
-        if: success() || failure()
-        run: |
-          echo "The status is: '${{ steps.rl-scan.outputs.status }}'"
-          echo "The description is: '${{ steps.rl-scan.outputs.description }}'"
+          rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}
       - name: Archive scan report
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -42,8 +42,9 @@ jobs:
   
   threat-assessment:
     if: github.event_name == 'release' && github.event.action == 'published'
-    name: Threat Assessment
+    name: Threat assessment
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: test
     steps:
       - uses: actions/checkout@v4
@@ -51,19 +52,19 @@ jobs:
         id: get_version
         run: |
           # Extract the version from package.json and set it as an environment variable
-          echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+          echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       # Create an archive of the package
-      - name: Set Current Date Time
+      - name: Set current datetime
         run: |
           echo "DT_NOW=$(date +%Y%m%d-%H%M%S)" >> ${GITHUB_ENV}
       - name: Create directories
         run: mkdir -p build report
-      - id: build
+      - id: pack_artifact
         run: |
           npm pack --pack-destination build
           # Capture the path of the generated tarball
-          echo "scanfile=$(ls build/*.tgz)" >> $GITHUB_OUTPUT
+          echo "scan_file=$(ls build/*.tgz)" >> $GITHUB_OUTPUT
       # Use the rl-scanner-cloud-composite action
       - name: Scan build artifact on the Portal
         id: rl-scan
@@ -77,7 +78,7 @@ jobs:
           rl-portal-group: OSS-MannySilva
           rl-timeout: 20
           rl-submit-only: false
-          artifact-to-scan: ${{ steps.build.outputs.scanfile }}
+          artifact-to-scan: ${{ steps.pack_artifact.outputs.scan_file }}
           report-path: report
           rl-package-url: common/releases@${{ steps.get_version.outputs.version }}
       - name: Archive scan report
@@ -116,7 +117,7 @@ jobs:
         id: get_version
         run: |
           # Extract the version from package.json and set it as an environment variable
-          echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+          echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       - name: Update `resolver`
         run: |
@@ -131,4 +132,3 @@ jobs:
                -H "Accept: application/vnd.github.everest-preview+json" \
                "https://api.github.com/repos/doc-detective/doc-detective.github.io/dispatches" \
                -d '{"event_type": "update-common-package-event", "client_payload": {"version": "${{ steps.get_version.outputs.version }}"} }'
-

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -53,11 +53,12 @@ jobs:
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       # Create an archive of the package
+      - run: mkdir -p build
       - id: build
         run: |
           npm pack
           # Capture the path of the generated tarball
-          echo "scanfile=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "scanfile=$(ls build/*.tgz)" >> $GITHUB_OUTPUT
       # Use the rl-scanner-cloud-composite action
       - name: Scan build artifact on the Portal
         id: rl-scan
@@ -73,6 +74,11 @@ jobs:
           rl-submit-only: false
           artifact-to-scan: ${{ steps.build.outputs.scanfile }}
           rl-package-url: common/Releases@${{ steps.get_version.outputs.version }}-assess.0
+      - name: Output scan status
+        if: success() || failure()
+        run: |
+          echo "The status is: '${{ steps.rl-scan.outputs.status }}'"
+          echo "The description is: '${{ steps.rl-scan.outputs.description }}'"
 
   publish-npm:
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Introduce a threat assessment job in the CI workflow that extracts the package version, creates an archive, and scans the build artifact. Enhance the workflow with improved reporting and archiving features, ensuring the threat assessment runs before publishing to NPM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated security scan for release artifacts before publishing.
  * Updated the release workflow to require a successful security assessment prior to publishing to npm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->